### PR TITLE
Update INSTALL-Linux.markdown

### DIFF
--- a/INSTALL-Linux.markdown
+++ b/INSTALL-Linux.markdown
@@ -17,7 +17,7 @@ Dependencies
 
 Ubuntu and Debian package dependencies
 --------------------------------------
-    apt-get install iptables libcap-dev libssl-dev \
+    apt-get install iptables libcap-dev libssl-dev libtool \
                     libnfnetlink-dev libnetfilter-queue-dev
 
 
@@ -58,6 +58,7 @@ Compiling
 Run:
 
     cd tcpcrypt
+    mkdir m4
     ./bootstrap.sh
     ./configure
     make


### PR DESCRIPTION
During the bootstrap it launched me this errors:

Use of uninitialized value in pattern match (m//) at /usr/bin/autoreconf line 196.
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
aclocal: couldn't open directory`m4': El fitxer o directori no existeix
autoreconf: aclocal failed with exit status: 1

I needed to install libtool and create the directory m4 inside the root of the folder to adress those issues.
