### PR TITLE
Add ENO option in ACK, as required by ENO section 3.2

### DIFF
--- a/src/tcpcrypt.c
+++ b/src/tcpcrypt.c
@@ -1182,7 +1182,21 @@ static int do_output_pkconf_rcvd(struct tc *tc, struct ip *ip,
 	int len, klen;
 	struct tc_init1 *init1;
 	void *key;
+	struct tcpopt_eno *eno;
 	uint8_t *p;
+
+	/* Add the minimal ENO option to indicate support */
+	len = sizeof(*eno) + sizeof(tc->tc_cipher_pkey);
+	eno = tcp_opts_alloc(tc, ip, tcp, len);
+	if (!eno) {
+		xprintf(XP_ALWAYS, "No space for ENO\n");
+		tc->tc_state = STATE_DISABLED;
+
+		return DIVERT_ACCEPT;
+	}
+	eno->toe_kind = TCPOPT_ENO;
+	eno->toe_len  = len;
+	memcpy(eno->toe_opts, &tc->tc_cipher_pkey, sizeof(tc->tc_cipher_pkey));
 
 	if (!retx)
 		generate_nonce(tc, tc->tc_crypt_pub->cp_n_c);
@@ -2142,12 +2156,26 @@ static int do_input_pkconf_sent(struct tc *tc, struct ip *ip,
 	struct tc_init2 *i2;
 	uint8_t kxs[1024];
 	int cipherlen;
+	struct tcpopt_eno *eno;
+
+	/* Check to see if the other side added ENO per
+	   Section 3.2 of draft-ietf-tcpinc-tcpeno-00. */
+	if (!(eno = find_opt(tcp, TCPOPT_ENO))) {
+		xprintf(XP_DEBUG, "No ENO option found in expected INIT1\n");
+		tc->tc_state = STATE_DISABLED;
+
+		return DIVERT_ACCEPT;
+	}
 
 	/* syn retransmission */
 	if (tcp->th_flags == TH_SYN)
 		return do_input_closed(tc, ip, tcp);
 
 	if (!process_init1(tc, ip, tcp, kxs, sizeof(kxs))) {
+		/* XXX. Per Section 3.2 of draft-ietf-tcpinc-tcpeno-00,
+		   you are supposed to tear down the connection.
+		   This is a bug.
+		*/
 		tc->tc_state = STATE_DISABLED;
 
 		return DIVERT_ACCEPT;


### PR DESCRIPTION
Section 3.2 requires that endpoints send an ENO option in the first bare ACK, but the current implementation seems not to:
12:06:32.024985 IP 127.0.0.1.58297 > 127.0.0.1.2000: Flags [S], seq 3546215307, win 43690, options [mss 65495,nop,nop,TS val 1013787 ecr 0,nop,wscale 7,unknown-71 0x2122], length 0
12:06:32.025139 IP 127.0.0.1.2000 > 127.0.0.1.58297: Flags [S.], seq 729814105, ack 3546215308, win 43690, options [mss 65495,nop,nop,TS val 1013787 ecr 1013787,nop,wscale 7,unknown-71 0x21,eol], length 0
12:06:32.025265 IP 127.0.0.1.58297 > 127.0.0.1.2000: Flags [.], seq 1:105, ack 1, win 342, options [nop,nop,TS val 1013787 ecr 1013787], length 104



This patch adds that for the non-resumed handshake, and also adds checking for it.

11:52:49.560395 IP 127.0.0.1.58296 > 127.0.0.1.2000: Flags [S], seq 1792226566, win 43690, options [mss 65495,nop,nop,TS val 808171 ecr 0,nop,wscale 7,unknown-71 0x2122], length 0
11:52:49.560637 IP 127.0.0.1.2000 > 127.0.0.1.58296: Flags [S.], seq 814875170, ack 1792226567, win 43690, options [mss 65495,nop,nop,TS val 808171 ecr 808171,nop,wscale 7,unknown-71 0x21,eol], length 0
11:52:49.560856 IP 127.0.0.1.58296 > 127.0.0.1.2000: Flags [.], seq 1:105, ack 1, win 342, options [nop,nop,TS val 808171 ecr 808171,unknown-71 0x21,eol], length 104