### PR TITLE
Use PF_DIVERT on FreeBSD 14 and beyond.

### DIFF
--- a/src/freebsd.c
+++ b/src/freebsd.c
@@ -24,7 +24,11 @@ static int bsd_open(int port, divert_cb cb)
 	s_in.sin_family = PF_INET;
 	s_in.sin_port   = htons(port);
 
+#ifdef PF_DIVERT
+	if ((_s = socket(PF_DIVERT, SOCK_RAW, 0)) == -1)
+#else
 	if ((_s = socket(PF_INET, SOCK_RAW, IPPROTO_DIVERT)) == -1)
+#endif
 		err(1, "socket()");
 
 	if (bind(_s, (struct sockaddr*) &s_in, sizeof(s_in)) == -1)


### PR DESCRIPTION
In FreeBSD the API changed a bit: https://cgit.freebsd.org/src/commit/?id=8624f4347e8133911b0554e816f6bedb56dc5fb3

Make tcpcrypt work without warnings.
